### PR TITLE
WinRT: add IAsyncInfo

### DIFF
--- a/Sources/WinRT/IAsyncInfo+Swift.swift
+++ b/Sources/WinRT/IAsyncInfo+Swift.swift
@@ -1,0 +1,24 @@
+// Copyright © 2021 Saleem Abdulrasool <compnerd@compnerd.org>
+// SPDX-License-Identifier: BSD-3
+
+import CWinRT
+
+extension IAsyncInfo {
+  public var Id: Int {
+    var id: CUnsignedInt = .max
+    try! self.get_Id(&id)
+    return Int(id)
+  }
+
+  public var Status: AsyncStatus {
+    var status: AsyncStatus = CWinRT.Error
+    try! self.get_Status(&status)
+    return status
+  }
+
+  public var ErrorCode: HRESULT {
+    var errorCode: HRESULT = S_OK
+    try! self.get_ErrorCode(&errorCode)
+    return errorCode;
+  }
+}

--- a/Sources/WinRT/IAsyncInfo.swift
+++ b/Sources/WinRT/IAsyncInfo.swift
@@ -1,0 +1,38 @@
+// Copyright © 2021 Saleem Abdulrasool <compnerd@compnerd.org>
+// SPDX-License-Identifier: BSD-3
+
+import CWinRT
+
+public class IAsyncInfo: IInspectable {
+  override open class var IID: IID { IID_IAsyncInfo }
+
+  public func get_Id(_ id: UnsafeMutablePointer<CUnsignedInt>?) throws {
+    return try perform(as: CWinRT.IAsyncInfo.self) { pThis in
+      try CHECKED(pThis.pointee.lpVtbl.pointee.get_Id(pThis, id))
+    }
+  }
+
+  public func get_Status(_ status: UnsafeMutablePointer<AsyncStatus>?) throws {
+    return try perform(as: CWinRT.IAsyncInfo.self) { pThis in
+      try CHECKED(pThis.pointee.lpVtbl.pointee.get_Status(pThis, status))
+    }
+  }
+
+  public func get_ErrorCode(_ errorCode: UnsafeMutablePointer<HRESULT>?) throws {
+    return try perform(as: CWinRT.IAsyncInfo.self) { pThis in
+      try CHECKED(pThis.pointee.lpVtbl.pointee.get_ErrorCode(pThis, errorCode))
+    }
+  }
+
+  public func Cancel() throws {
+    return try perform(as: CWinRT.IAsyncInfo.self) { pThis in
+      try CHECKED(pThis.pointee.lpVtbl.pointee.Cancel(pThis))
+    }
+  }
+
+  public func Close() throws {
+    return try perform(as: CWinRT.IAsyncInfo.self) { pThis in
+      try CHECKED(pThis.pointee.lpVtbl.pointee.Close(pThis))
+    }
+  }
+}


### PR DESCRIPTION
The `IAsyncInfo` type defines the basis for the async operation returns
(futures) in the WinRT type hierarchy.  Being fleshing out the async
result types to handle the more interesting API surface in WinRT.