### PR TITLE
Support: allow `nil` for `HSTRING` in `String` construction

### DIFF
--- a/Sources/WinRT/Support/Swift+Extensions.swift
+++ b/Sources/WinRT/Support/Swift+Extensions.swift
@@ -4,7 +4,7 @@
 import CWinRT
 
 extension String {
-  internal init(from hString: HSTRING) {
+  internal init(from hString: HSTRING?) {
     var length: UINT32 = 0
     let pwszBuffer: PCWSTR = WindowsGetStringRawBuffer(hString, &length)
     self.init(decoding: UnsafeBufferPointer(start: pwszBuffer, count: Int(length)), as: UTF16.self)


### PR DESCRIPTION
`HSTRING?` is the proper parameter type as the value `nil` is equivalent
to the empty string.