### PR TITLE
COM: alter the `IUnknown` interface

### DIFF
--- a/Sources/WinRT/ABI/Windows/Security/Cryptography/ICryptographicBufferStatics+Swift.swift
+++ b/Sources/WinRT/ABI/Windows/Security/Cryptography/ICryptographicBufferStatics+Swift.swift
@@ -13,7 +13,7 @@ extension ICryptographicBufferStatics {
   public func GenerateRandom(_ length: UINT32) throws -> IBuffer {
     var buffer: UnsafeMutablePointer<__x_ABI_CWindows_CStorage_CStreams_CIBuffer>?
     try self.GenerateRandom(length, &buffer)
-    return IBuffer(pUnk: buffer)
+    return IBuffer(consuming: buffer)
   }
 
   public func GenerateRandomNumber() throws -> UINT32 {
@@ -27,7 +27,7 @@ extension ICryptographicBufferStatics {
     return try array.withUnsafeMutableBufferPointer {
       var buffer: UnsafeMutablePointer<__x_ABI_CWindows_CStorage_CStreams_CIBuffer>?
       try self.CreateFromByteArray(UINT32($0.count), $0.baseAddress, &buffer)
-      return IBuffer(pUnk: buffer)
+      return IBuffer(consuming: buffer)
     }
   }
 
@@ -36,7 +36,7 @@ extension ICryptographicBufferStatics {
     return try withExtendedLifetime(hString) {
       var buffer: UnsafeMutablePointer<__x_ABI_CWindows_CStorage_CStreams_CIBuffer>?
       try self.DecodeFromHexString(hString.hRef.hString, &buffer)
-      return IBuffer(pUnk: buffer)
+      return IBuffer(consuming: buffer)
     }
   }
 
@@ -51,7 +51,7 @@ extension ICryptographicBufferStatics {
     return try withExtendedLifetime(hString) {
       var buffer: UnsafeMutablePointer<__x_ABI_CWindows_CStorage_CStreams_CIBuffer>?
       try self.DecodeFromBase64String(hString.hRef.hString, &buffer)
-      return IBuffer(pUnk: buffer)
+      return IBuffer(consuming: buffer)
     }
   }
 
@@ -66,7 +66,7 @@ extension ICryptographicBufferStatics {
     return try withExtendedLifetime(hString) {
       var buffer: UnsafeMutablePointer<__x_ABI_CWindows_CStorage_CStreams_CIBuffer>?
       try self.ConvertStringToBinary(hString.hRef.hString, encoding, &buffer)
-      return IBuffer(pUnk: buffer)
+      return IBuffer(consuming: buffer)
     }
   }
 

--- a/Sources/WinRT/ABI/Windows/System/IDispatcherQueueController+Swift.swift
+++ b/Sources/WinRT/ABI/Windows/System/IDispatcherQueueController+Swift.swift
@@ -7,12 +7,12 @@ extension IDispatcherQueueController {
   public var get_DispatcherQueue: IDispatcherQueue {
     var value: UnsafeMutablePointer<__x_ABI_CWindows_CSystem_CIDispatcherQueue>?
     try! self.get_DispatcherQueue(&value)
-    return IDispatcherQueue(pUnk: value)
+    return IDispatcherQueue(consuming: value)
   }
 
   public func ShutdownQueueAsync() throws -> IAsyncAction {
     var operation: UnsafeMutablePointer<__x_ABI_CWindows_CFoundation_CIAsyncAction>?
     try self.ShutdownQueueAsync(&operation)
-    return IAsyncAction(pUnk: operation)
+    return IAsyncAction(consuming: operation)
   }
 }

--- a/Sources/WinRT/ABI/Windows/System/Profile/ISystemIdentificationInfo+Swift.swift
+++ b/Sources/WinRT/ABI/Windows/System/Profile/ISystemIdentificationInfo+Swift.swift
@@ -7,7 +7,7 @@ extension ISystemIdentificationInfo {
   public var Id: IBuffer {
     var value: UnsafeMutablePointer<__x_ABI_CWindows_CStorage_CStreams_CIBuffer>?
     try! self.get_Id(&value)
-    return IBuffer(pUnk: value)
+    return IBuffer(consuming: value)
   }
 
   public var Source: SystemIdentificationSource {

--- a/Sources/WinRT/ABI/Windows/System/Profile/ISystemIdentificationStatics+Swift.swift
+++ b/Sources/WinRT/ABI/Windows/System/Profile/ISystemIdentificationStatics+Swift.swift
@@ -7,12 +7,12 @@ extension ISystemIdentificationStatics {
   public func GetSystemIdForPublisher() throws -> ISystemIdentificationInfo {
     var result: UnsafeMutablePointer<__x_ABI_CWindows_CSystem_CProfile_CISystemIdentificationInfo>?
     try self.GetSystemIdForPublisher(&result)
-    return ISystemIdentificationInfo(pUnk: result)
+    return ISystemIdentificationInfo(consuming: result)
   }
 
   public func GetSystemIdForUser(_ user: IUser) throws -> ISystemIdentificationInfo {
     var result: UnsafeMutablePointer<__x_ABI_CWindows_CSystem_CProfile_CISystemIdentificationInfo>?
     try self.GetSystemIdForUser(RawPointer(user), &result)
-    return ISystemIdentificationInfo(pUnk: result)
+    return ISystemIdentificationInfo(consuming: result)
   }
 }

--- a/Sources/WinRT/COM/IUnknown+Swift.swift
+++ b/Sources/WinRT/COM/IUnknown+Swift.swift
@@ -10,7 +10,7 @@ extension IUnknown {
     var iid: IID = Interface.IID
     var pointer: UnsafeMutableRawPointer?
     try CHECKED(pUnk.pointee.lpVtbl.pointee.QueryInterface(pUnk, &iid, &pointer))
-    return Interface(pUnk: pointer)
+    return Interface(consuming: pointer?.bindMemory(to: WinSDK.IUnknown.self, capacity: 1))
   }
 }
 
@@ -24,7 +24,7 @@ extension IUnknown {
 
     var pointer: UnsafeMutableRawPointer?
     try CHECKED(CoCreateInstance(&clsid, RawPointer(pUnkOuter), DWORD(dwClsContext.rawValue), &iid, &pointer))
-    return Interface(pUnk: pointer)
+    return Interface(consuming: pointer?.bindMemory(to: WinSDK.IUnknown.self, capacity: 1))
   }
 }
 

--- a/Sources/WinRT/COM/IUnknown.swift
+++ b/Sources/WinRT/COM/IUnknown.swift
@@ -9,8 +9,24 @@ open class IUnknown {
 
   open class var IID: IID { IID_IUnknown }
 
-  public required init(pUnk pointer: UnsafeMutableRawPointer?) {
-    self.pUnk = IUnknownRef(consuming: pointer?.bindMemory(to: WinSDK.IUnknown.self, capacity: 1))
+  public required init(_ pointer: UnsafeMutablePointer<WinSDK.IUnknown>?) {
+    self.pUnk = IUnknownRef(pointer)
+  }
+
+  public convenience init(_ pointer: UnsafeMutableRawPointer?) {
+    let pUnk: UnsafeMutablePointer<WinSDK.IUnknown>? =
+        pointer?.bindMemory(to: WinSDK.IUnknown.self, capacity: 1)
+    self.init(pUnk)
+  }
+
+  public required init(consuming pointer: UnsafeMutablePointer<WinSDK.IUnknown>?) {
+    self.pUnk = IUnknownRef(consuming: pointer)
+  }
+
+  public convenience init(consuming pointer: UnsafeMutableRawPointer?) {
+    let pUnk: UnsafeMutablePointer<WinSDK.IUnknown>? =
+        pointer?.bindMemory(to: WinSDK.IUnknown.self, capacity: 1)
+    self.init(consuming: pUnk)
   }
 
   @_alwaysEmitIntoClient @inline(__always)

--- a/Sources/WinRT/Runtime+Swift.swift
+++ b/Sources/WinRT/Runtime+Swift.swift
@@ -11,11 +11,11 @@ public func RoGetActivationFactory<Factory: IInspectable>(_ activatableClassId: 
   var iid: IID = Factory.IID
   var factory: UnsafeMutableRawPointer?
   try CHECKED(RoGetActivationFactory(activatableClassId.hRef.hString, &iid, &factory))
-  return Factory(pUnk: factory)
+  return Factory(consuming: factory?.bindMemory(to: WinSDK.IUnknown.self, capacity: 1))
 }
 
 public func RoActivateInstance<Instance: IInspectable>(_ activatableClassId: HString) throws -> Instance {
   var instance: UnsafeMutablePointer<CWinRT.IInspectable>?
   try CHECKED(RoActivateInstance(activatableClassId.hRef.hString, &instance))
-  return Instance(pUnk: instance)
+  return Instance(consuming: UnsafeMutableRawPointer(instance)?.bindMemory(to: WinSDK.IUnknown.self, capacity: 1))
 }


### PR DESCRIPTION
Make the `IUnknown` interface far more explicit about memory management.
This alters the `IUnknown` interface to:
- `IUnknown.init(consuming:)`: takes a retained value
- `IUnknown.init(_:)`: takes an unretained value

We can now handle the lifetime precisely to avoid incorrect lifetimes
when implementing the interfaces in Swift and passing them to C/C++.