### PR TITLE
Support: add `Future` protocol

### DIFF
--- a/Sources/WinRT/Support/Future.swift
+++ b/Sources/WinRT/Support/Future.swift
@@ -1,0 +1,44 @@
+// Copyright © 2021 Saleem Abdulrasool <compnerd@compnerd.org>
+// SPDX-License-Identifier: BSD-3
+
+import CWinRT
+
+internal protocol Future {
+  associatedtype ValueType
+  func get() throws -> ValueType
+}
+
+extension IAsyncAction: Future {
+  private final class CompletedHandler: AsyncActionCompletedHandler {
+    private var hEvent: HANDLE
+
+    public init(signal event: HANDLE) {
+      self.hEvent = event
+      super.init()
+    }
+
+    override func Invoke(_ asyncInfo: IAsyncAction?,
+                         _ asyncStatus: AsyncStatus) -> HRESULT {
+      _ = SetEvent(self.hEvent)
+      return S_OK
+    }
+  }
+
+  internal func get() throws -> Void {
+    let info: IAsyncInfo = try QueryInterface()
+    if info.Status == CWinRT.Started {
+      let event: HANDLE =
+          CreateEventW(nil, /*bManualReset=*/true, /*DefaultValue=*/false, nil)
+      // TODO(compnerd) validate event
+      defer { _ = CloseHandle(event) }
+
+      let completion: AsyncActionCompletedHandler =
+          IAsyncAction.CompletedHandler(signal: event)
+      try withExtendedLifetime(completion) {
+        try self.put_Completed(RawPointer(Interface(completion)))
+        _ = WaitForSingleObject(event, INFINITE)
+      }
+    }
+    try self.GetResults()
+  }
+}


### PR DESCRIPTION
The `Future` protocol allows a conforming type to be used as a future.
The protocol is meant to be adopted by promises.  A conforming promise
provides the `get` method which will evaluate the promise and return a
value for the promise.  This is meant to be used in the implementation
for async routines.