### PR TITLE
ABI: extend the `IDispatcherQueueController` wrapping

### DIFF
--- a/Sources/WinRT/ABI/Windows/System/IDispatcherQueueController+Swift.swift
+++ b/Sources/WinRT/ABI/Windows/System/IDispatcherQueueController+Swift.swift
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: BSD-3
 
 import CWinRT
+import _Concurrency
 
 extension IDispatcherQueueController {
   public var get_DispatcherQueue: IDispatcherQueue {
@@ -14,5 +15,17 @@ extension IDispatcherQueueController {
     var operation: UnsafeMutablePointer<__x_ABI_CWindows_CFoundation_CIAsyncAction>?
     try self.ShutdownQueueAsync(&operation)
     return IAsyncAction(consuming: operation)
+  }
+}
+
+extension IDispatcherQueueController {
+  public func ShutdownQueue() async throws {
+    return try await withUnsafeThrowingContinuation { continuation in
+      do {
+        return try continuation.resume(returning: self.ShutdownQueueAsync().get())
+      } catch let error {
+        return continuation.resume(throwing: error)
+      }
+    }
   }
 }


### PR DESCRIPTION
This provides the first of the wrapping routines that truly bridge WinRT
to Swift.  The `ShutdownQueueAsync` function is further extended towards
a Swift friendly interface.  The `Async` suffix is stripped and the func
implemented as an `async` overload.  This function can now be invoked in
an async context with the `await` keyword enabling native concurrency to
be used with the WinRT model.