### PR TITLE
demo: add a demo to experiment with async APIs

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -6,6 +6,7 @@ let SwiftWinRT = Package(
   name: "SwiftWinRT",
   products: [
     .executable(name: "WinRTDemo", targets: ["WinRTDemo"]),
+    .executable(name: "WinRTAsyncDemo", targets: ["WinRTAsyncDemo"]),
     .library(name: "SwiftWinRT", type: .dynamic, targets: ["WinRT"]),
   ],
   targets: [
@@ -13,6 +14,10 @@ let SwiftWinRT = Package(
     .target(name: "WinRT", dependencies: ["CWinRT"],
             linkerSettings: [
               .linkedLibrary("Ole32"),
+            ]),
+    .target(name: "WinRTAsyncDemo", dependencies: ["WinRT"],
+            swiftSettings: [
+              .unsafeFlags(["-parse-as-library"]),
             ]),
     .target(name: "WinRTDemo", dependencies: ["WinRT"],
             swiftSettings: [

--- a/Sources/WinRTAsyncDemo/main.swift
+++ b/Sources/WinRTAsyncDemo/main.swift
@@ -1,0 +1,18 @@
+// Copyright © 2021 Saleem Abdulrasool <compnerd@compnerd.org>
+// SPDX-License-Identifier: BSD-3
+
+import WinRT
+
+@main
+class WinRTAsyncDemo {
+  public static func main() async throws {
+    try RoInitialize()
+
+    let controller: IDispatcherQueueController =
+        try Windows.System.DispatcherQueueController.CreateOnDedicatedThread()
+
+    try await controller.ShutdownQueue()
+
+    print("Done!")
+  }
+}


### PR DESCRIPTION
This adds a sample for the use of `async` with the WinRT APIs.