### PR TITLE
WinRT: use effectful properties

### DIFF
--- a/Sources/WinRT/ABI/Windows/Storage/Streams/IBuffer+Swift.swift
+++ b/Sources/WinRT/ABI/Windows/Storage/Streams/IBuffer+Swift.swift
@@ -2,12 +2,15 @@
 // SPDX-License-Identifier: BSD-3
 
 import WinSDK
+import _Concurrency
 
 extension IBuffer {
   public var Capacity: UINT32 {
-    var value: UINT32 = .max
-    try! self.get_Capacity(&value)
-    return value
+    get throws {
+      var value: UINT32 = .max
+      try self.get_Capacity(&value)
+      return value
+    }
   }
 
   public var Length: UINT32 {

--- a/Sources/WinRT/ABI/Windows/System/IDispatcherQueueController+Swift.swift
+++ b/Sources/WinRT/ABI/Windows/System/IDispatcherQueueController+Swift.swift
@@ -5,10 +5,12 @@ import CWinRT
 import _Concurrency
 
 extension IDispatcherQueueController {
-  public var get_DispatcherQueue: IDispatcherQueue {
-    var value: UnsafeMutablePointer<__x_ABI_CWindows_CSystem_CIDispatcherQueue>?
-    try! self.get_DispatcherQueue(&value)
-    return IDispatcherQueue(consuming: value)
+  public var DispatcherQueue: IDispatcherQueue {
+    get throws {
+      var value: UnsafeMutablePointer<__x_ABI_CWindows_CSystem_CIDispatcherQueue>?
+      try self.get_DispatcherQueue(&value)
+      return IDispatcherQueue(consuming: value)
+    }
   }
 
   public func ShutdownQueueAsync() throws -> IAsyncAction {

--- a/Sources/WinRT/ABI/Windows/System/Profile/ISystemIdentificationInfo+Swift.swift
+++ b/Sources/WinRT/ABI/Windows/System/Profile/ISystemIdentificationInfo+Swift.swift
@@ -2,17 +2,22 @@
 // SPDX-License-Identifier: BSD-3
 
 import CWinRT
+import _Concurrency
 
 extension ISystemIdentificationInfo {
   public var Id: IBuffer {
-    var value: UnsafeMutablePointer<__x_ABI_CWindows_CStorage_CStreams_CIBuffer>?
-    try! self.get_Id(&value)
-    return IBuffer(consuming: value)
+    get throws {
+      var value: UnsafeMutablePointer<__x_ABI_CWindows_CStorage_CStreams_CIBuffer>?
+      try self.get_Id(&value)
+      return IBuffer(consuming: value)
+    }
   }
 
   public var Source: SystemIdentificationSource {
-    var value: SystemIdentificationSource = .none
-    try! self.get_Source(&value)
-    return value
+    get throws {
+      var value: SystemIdentificationSource = .none
+      try self.get_Source(&value)
+      return value
+    }
   }
 }

--- a/Sources/WinRT/IAsyncInfo+Swift.swift
+++ b/Sources/WinRT/IAsyncInfo+Swift.swift
@@ -2,23 +2,30 @@
 // SPDX-License-Identifier: BSD-3
 
 import CWinRT
+import _Concurrency
 
 extension IAsyncInfo {
   public var Id: Int {
-    var id: CUnsignedInt = .max
-    try! self.get_Id(&id)
-    return Int(id)
+    get throws {
+      var id: CUnsignedInt = .max
+      try self.get_Id(&id)
+      return Int(id)
+    }
   }
 
   public var Status: AsyncStatus {
-    var status: AsyncStatus = CWinRT.Error
-    try! self.get_Status(&status)
-    return status
+    get throws {
+      var status: AsyncStatus = CWinRT.Error
+      try self.get_Status(&status)
+      return status
+    }
   }
 
   public var ErrorCode: HRESULT {
-    var errorCode: HRESULT = S_OK
-    try! self.get_ErrorCode(&errorCode)
-    return errorCode;
+    get throws {
+      var errorCode: HRESULT = S_OK
+      try self.get_ErrorCode(&errorCode)
+      return errorCode
+    }
   }
 }

--- a/Sources/WinRT/Support/Future.swift
+++ b/Sources/WinRT/Support/Future.swift
@@ -26,7 +26,7 @@ extension IAsyncAction: Future {
 
   internal func get() throws -> Void {
     let info: IAsyncInfo = try QueryInterface()
-    if info.Status == CWinRT.Started {
+    if try info.Status == CWinRT.Started {
       let event: HANDLE =
           CreateEventW(nil, /*bManualReset=*/true, /*DefaultValue=*/false, nil)
       // TODO(compnerd) validate event

--- a/Sources/WinRTDemo/main.swift
+++ b/Sources/WinRTDemo/main.swift
@@ -11,7 +11,7 @@ class WinRTDemo {
     let buffer: ISystemIdentificationInfo =
         try Windows.System.Profile.SystemIdentification.GetSystemIdForPublisher()
 
-    let id: IBuffer = buffer.Id
+    let id: IBuffer = try buffer.Id
 
     let hex: String =
         try Windows.Security.Cryptography.CryptographicBuffer.EncodeToHexString(id)


### PR DESCRIPTION
Use the new `get throws` effectful property for read-only access to
properties.  This bridges the COM interfaces to Swift in a nicer manner.